### PR TITLE
Form\Element 增加 custom() 方法

### DIFF
--- a/src/core/UI/Form/Element.php
+++ b/src/core/UI/Form/Element.php
@@ -38,6 +38,10 @@ class Element
     protected $value;
     protected $default;
 
+    /**
+     * @var \Closure|null 自定义回调函数(格式化字段)
+     */
+    protected ?\Closure $formatFunc = null;
 
     /**
      * 设置弹窗
@@ -442,6 +446,22 @@ class Element
         return (array)$this->format['all'] + (array)$this->format[$time];
     }
 
+    /**
+     * 自定义回调函数
+     * (格式化字段，适用于跨字段读取数据)
+     * e.g.
+     * $form->text('URL', 'url')->custom(function ($info) {
+     *     return $info->scheme . '://' . $info->url;
+     * });
+     *
+     * @param  \Closure $func
+     * @return $this
+     */
+    public function custom(\Closure $func)
+    {
+        $this->formatFunc = $func;
+        return $this;
+    }
 
     /**
      * 获取提交数据
@@ -529,6 +549,12 @@ class Element
         } else {
             $value = $this->getValue($value);
         }
+
+        // 自定义回调函数(格式化字段)
+        if ($this->formatFunc && is_callable($this->formatFunc)) {
+            $value = call_user_func($this->formatFunc, $info);
+        }
+
         $data[$this->getField()] = $value;
 
         return $data;

--- a/src/core/Util/Route.php
+++ b/src/core/Util/Route.php
@@ -190,7 +190,7 @@ class Route
     private function addItemDel(string $app, string $layout, string $name, string $class): array
     {
         return [
-            'type' => 'post',
+            'type' => ['get', 'post'],
             'rule' => $this->prefix . '/del/{id?}',
             'uses' => $class . '@del',
             'desc' => '删除',


### PR DESCRIPTION
改进①：Route::addItemDel() 路由类型增加GET

原因: 默认只支持POST，而开发文档示例却只写了GET方式，不利于小白。

增加GET，既符合了Expend::del()同时支持GET/POST的实现，也符合删除类的URL风格

---
改进②：Form\Element 增加 custom() 方法

背景：表单字段展示，存在自定义格式化，比如原字段叫url，展示时需要加上scheme。

示例：
```php
$form->text('URL', 'url')->custom(function ($info) {
    return $info->scheme . '://' . $info->url;
});
```